### PR TITLE
Fix uniques in Sluggable

### DIFF
--- a/Model/Behavior/SluggableBehavior.php
+++ b/Model/Behavior/SluggableBehavior.php
@@ -116,7 +116,7 @@ class SluggableBehavior extends ModelBehavior {
 	 */
 	protected function _makeUnique(Model $model, $string) {
 		$settings = $this->settings[$model->alias];
-		$conditions = array($settings['slug'] . ' LIKE' => '%' . $string) + $settings['scope'];
+		$conditions = array($settings['slug'] . ' LIKE' => $string . '%') + $settings['scope'];
 
 		if ($model->id) {
 			$conditions[$model->primaryKey . ' !='] = $model->id;


### PR DESCRIPTION
In the _makeUnique function the unique count is being added to the end of the string. The condition now matchs this behaviour.
