### PR TITLE
Fix for storyEmpty and forceRefresh

### DIFF
--- a/Model/Behavior/CacheableBehavior.php
+++ b/Model/Behavior/CacheableBehavior.php
@@ -320,7 +320,7 @@ class CacheableBehavior extends ModelBehavior {
             $this->deleteCache($model, array($model->alias . '::' . $getCount));
         }
 
-        return $created;
+        return true;
     }
 
     /**


### PR DESCRIPTION
storyEmpty: if(!$results) is not adequate to detect empty arrays
forceRefresh: not sure if you like this implementation which allows future options you may want to add.
